### PR TITLE
RATESWSX-312: installment: fix issue that if payment-type is not available, shopware may select this payment type with `FormPreserverPlugin`

### DIFF
--- a/src/Resources/views/storefront/installment-calculator/installment-plan.html.twig
+++ b/src/Resources/views/storefront/installment-calculator/installment-plan.html.twig
@@ -130,22 +130,27 @@
     {% set code_directDebit = constant('Ratepay\\RpayPayments\\Components\\ProfileConfig\\Model\\ProfileConfigMethodInstallmentEntity::PAYMENT_TYPE_DIRECT_DEBIT') %}
     {% set code_bankTransfer = constant('Ratepay\\RpayPayments\\Components\\ProfileConfig\\Model\\ProfileConfigMethodInstallmentEntity::PAYMENT_TYPE_BANK_TRANSFER') %}
 
-    <input type="radio"
-           name="ratepay[installment][paymentType]"
-           class="rp__installment__paymentType"
-           id="rp__installment__paymentType_directDebit"
-           value="{{ code_directDebit }}"
-           form="confirmOrderForm"
-           {% if ratepay.installment.plan.payment.default == code_directDebit %}checked="checked"{% endif %}
-    />
-    <input type="radio"
-           name="ratepay[installment][paymentType]"
-           class="rp__installment__paymentType"
-           id="rp__installment__paymentType_bankTransfer"
-           value="{{ code_bankTransfer }}"
-           form="confirmOrderForm"
-           {% if ratepay.installment.plan.payment.default == code_bankTransfer %}checked="checked"{% endif %}
-    />
+    {% if ratepay.installment.plan.payment.directDebitAllowed %}
+        <input type="radio"
+               name="ratepay[installment][paymentType]"
+               class="rp__installment__paymentType"
+               id="rp__installment__paymentType_directDebit"
+               value="{{ code_directDebit }}"
+               form="confirmOrderForm"
+               {% if ratepay.installment.plan.payment.default == code_directDebit %}checked="checked"{% endif %}
+        />
+    {% endif %}
+
+    {% if ratepay.installment.plan.payment.bankTransferAllowed %}
+        <input type="radio"
+               name="ratepay[installment][paymentType]"
+               class="rp__installment__paymentType"
+               id="rp__installment__paymentType_bankTransfer"
+               value="{{ code_bankTransfer }}"
+               form="confirmOrderForm"
+               {% if ratepay.installment.plan.payment.default == code_bankTransfer %}checked="checked"{% endif %}
+        />
+    {% endif %}
 
     {% if ratepay.installment.plan.payment.directDebitAllowed %}
         {# only show sepa form if the payment method is available #}


### PR DESCRIPTION
Steps to produce error:

1. select installment als payment method
2. switch to bank-transfer 
3. switch (back) to direct-debit
4. switch payment method to installment 0%
5. make sure that installment 0% is bank-transfer
6. place order

error: the module tries to create a direct-debit payment. 

This is caused by`FormPreserverPlugin` of Shopware. 
It will save all changes into the local storage (during the change of value). If the page got loaded, the values got placed again into the fields.

This PR will prevent outputting the radio-boxes for the payment switch. 
Only the available payment-types will have a radio-box. 
With this Shopwre can and will not select the radio-box